### PR TITLE
chore: expand backend pipeline logging coverage

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ import uvicorn
 from dotenv import load_dotenv
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from services.rtms_receiver_service import create_transcribe_router
+from services.debug_service import log_pipeline_step
 
 load_dotenv()
 
@@ -15,7 +16,11 @@ app = FastAPI(
 )
 
 DEBUG_MODE = os.getenv("DEBUG_MODE", "False").lower() == "true"
-print(f"  - Debug mode is: {'ON' if DEBUG_MODE else 'OFF'}")
+log_pipeline_step(
+    "SYSTEM",
+    f"Debug mode is: {'ON' if DEBUG_MODE else 'OFF'}",
+    detailed=False,
+)
 
 
 class ConnectionManager:
@@ -27,11 +32,21 @@ class ConnectionManager:
     async def connect(self, websocket: WebSocket):
         await websocket.accept()
         self.active_connections.append(websocket)
-        print(f"Viewer connected. Total viewers: {len(self.active_connections)}")
+        log_pipeline_step(
+            "WEBSOCKET",
+            "Viewer connected.",
+            extra={"total_viewers": len(self.active_connections)},
+            detailed=False,
+        )
 
     def disconnect(self, websocket: WebSocket):
         self.active_connections.remove(websocket)
-        print(f"Viewer disconnected. Total viewers: {len(self.active_connections)}")
+        log_pipeline_step(
+            "WEBSOCKET",
+            "Viewer disconnected.",
+            extra={"total_viewers": len(self.active_connections)},
+            detailed=False,
+        )
 
     async def broadcast(self, data: Dict[str, Any]):
         """Broadcasts a JSON object to all connected viewers."""

--- a/backend/services/vad_service.py
+++ b/backend/services/vad_service.py
@@ -4,6 +4,8 @@ from typing import Generator, Tuple
 
 import webrtcvad
 
+from .debug_service import log_pipeline_step
+
 
 # An Enum to make the VAD's state explicit and readable
 class VADState(Enum):
@@ -35,13 +37,29 @@ class VADService:
 
         num_padding_frames = int(padding_duration_ms / frame_duration_ms)
         self.ring_buffer = collections.deque(maxlen=num_padding_frames)
+        log_pipeline_step(
+            "VAD",
+            "Initialized VAD service.",
+            extra={
+                "sample_rate": sample_rate,
+                "frame_duration_ms": frame_duration_ms,
+                "aggressiveness": aggressiveness,
+                "padding_frames": num_padding_frames,
+            },
+            detailed=True,
+        )
 
         # Initialize the state
         self.reset()
 
     def reset(self):
         """Resets the VAD to its initial state."""
-        print("VAD service has been reset.")
+        log_pipeline_step(
+            "VAD",
+            "VAD service has been reset.",
+            extra={"padding_buffer_len": len(self.ring_buffer)},
+            detailed=False,
+        )
         self.state = VADState.WAITING
         self.ring_buffer.clear()
         self.utterance_buffer = bytearray()
@@ -68,6 +86,16 @@ class VADService:
             # This check is a safeguard; buffer_service should prevent this.
             return
 
+        log_pipeline_step(
+            "VAD",
+            "Evaluating audio frame for speech.",
+            extra={
+                "frame_bytes": len(frame),
+                "current_state": self.state.name,
+            },
+            detailed=True,
+        )
+
         is_speech = self.vad.is_speech(frame, self.sample_rate)
         self.ring_buffer.append((frame, is_speech))
 
@@ -76,15 +104,45 @@ class VADService:
             if self._is_speech_ratio(is_speech=True) > 0.9:
                 self.state = VADState.SPEAKING
                 start_audio = b"".join([f for f, _ in self.ring_buffer])
+                log_pipeline_step(
+                    "VAD",
+                    "Speech onset detected.",
+                    extra={
+                        "prebuffer_frames": len(start_audio) // self.frame_bytes,
+                        "prebuffer_bytes": len(start_audio),
+                    },
+                    detailed=False,
+                )
                 yield "start", start_audio
                 self.utterance_buffer.extend(start_audio)
                 self.ring_buffer.clear()
 
         elif self.state == VADState.SPEAKING:
             self.utterance_buffer.extend(frame)
+            log_pipeline_step(
+                "VAD",
+                "Speech frame appended to utterance buffer.",
+                extra={
+                    "utterance_bytes": len(self.utterance_buffer),
+                    "frame_bytes": len(frame),
+                },
+                detailed=True,
+            )
             yield "speech", frame
 
             # Check if we should transition back to WAITING
             if self._is_speech_ratio(is_speech=False) > 0.9:
+                utterance_length_ms = (
+                    len(self.utterance_buffer) / self.frame_bytes * self.frame_duration_ms
+                )
+                log_pipeline_step(
+                    "VAD",
+                    "Speech offset detected.",
+                    extra={
+                        "utterance_bytes": len(self.utterance_buffer),
+                        "approx_duration_ms": int(utterance_length_ms),
+                    },
+                    detailed=False,
+                )
                 yield "end", bytes(self.utterance_buffer)
                 self.reset()  # Reset for the next utterance


### PR DESCRIPTION
## Summary
- add DEBUG_MODE-aware logging across audio buffering, VAD, transcription, translation, and correction services so every utterance step is traceable
- instrument the audio processor and RTMS receiver pipeline to emit detailed metadata for buffering, queueing, and service calls when debugging is enabled
- normalize service imports to use package-local paths for the shared debug logger

## Testing
- python -m compileall backend zoom-rtms-server-dummy

------
https://chatgpt.com/codex/tasks/task_e_68d5b0ac494c832580a814863f8748aa